### PR TITLE
Update OpenCollective link to mycelium-dev

### DIFF
--- a/src/components/SupportContent.astro
+++ b/src/components/SupportContent.astro
@@ -142,7 +142,7 @@ const projects = getAllProjects();
             Transparence totale
           </p>
           <a
-            href="https://opencollective.com/mycelium-ecosystem"
+            href="https://opencollective.com/mycelium-dev"
             target="_blank"
             rel="noopener noreferrer"
             class="block w-full px-4 py-2 bg-mycelium-600 hover:bg-mycelium-700 text-white text-center rounded-lg font-medium transition-colors"

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -141,7 +141,7 @@ const base = import.meta.env.BASE_URL;
           </a>
 
           <a
-            href="https://opencollective.com/mycelium-ecosystem"
+            href="https://opencollective.com/mycelium-dev"
             target="_blank"
             rel="noopener noreferrer"
             class="block w-full px-6 py-3 rounded-lg font-medium text-center transition-all bg-white dark:bg-gray-700 border-2 border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:border-mycelium-500 dark:hover:border-mycelium-500"


### PR DESCRIPTION
Replace the OpenCollective URL in donation and support pages with the new mycelium-dev organization link.